### PR TITLE
Infrastructure

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "./avr-atmega328p.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "./flash.sh"
+
+[unstable]
+build-std = ["core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,6 @@ edition = "2018"
 name = "dot_games"
 path = "src/lib.rs"
 
-[build]
-target = "avr-atmega328p.json"
-rustflags = "--target avr-atmega328p.json"
-
-[target."avr-atmega328p.json"]
-runner = "./flash.sh"
-
-[unstable]
-build-std = ["core"]
-
 [profile.dev]
 panic = "abort"
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,13 @@ version = "0.1.0"
 authors = ["boggy"]
 edition = "2018"
 
+[bin]
+test = false
+
 [lib]
 name = "dot_games"
 path = "src/lib.rs"
+test = false
 
 [profile.dev]
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The GPIO pins are hardcoded as the following:
 ## Development
 Building:
 ```bash
-cargo build -Z build-std=core --target avr-atmega328p.json --release
+cargo build --release
 ```
 
 Flashing to arduino: 

--- a/src/games/selection.rs
+++ b/src/games/selection.rs
@@ -53,7 +53,7 @@ impl SelectionScreen {
     }
 
     /// Pass through function to get the title screen DotScreen object for the current game.
-    fn current_title_screen(&mut self) -> DotScreen {
+    fn current_title_screen(&mut self) -> &DotScreen {
         self.games[self.index].mut_ref_game().title_screen()
     }
 
@@ -79,7 +79,7 @@ impl SelectionScreen {
     /// This consumes the SelectionScreen object, returning the selected DotGame object.
     /// This will endlessly loop, reacting to inputs from the JoyStick peripheral.
     pub fn run(mut self, components: &mut crate::Components) -> DotGame {
-        components.display.show(&self.current_title_screen());
+        components.display.show(self.current_title_screen());
         return loop {
             match components.joystick.poll_until_any() {
                 InputSignal::JoyStick(signal) => {
@@ -91,11 +91,11 @@ impl SelectionScreen {
                     match signal.to_single_direction() {
                         Some(Direction::Left) => { 
                             self.prev();
-                            components.display.show(&self.current_title_screen());
+                            components.display.show(self.current_title_screen());
                         }
                         Some(Direction::Right) => {
                             self.next();
-                            components.display.show(&self.current_title_screen());
+                            components.display.show(self.current_title_screen());
                         }
                         _ => {}
                     }

--- a/src/games/snake.rs
+++ b/src/games/snake.rs
@@ -328,18 +328,20 @@ impl Game for SnakeGame {
     /// 
     /// # Returns
     /// The DotScreen object which displays as the title screen.
-    fn title_screen(&self) -> DotScreen {
-        DotScreen::new(
-            [
-                0b00000000,
-                0b00000000,
-                0b11011111,
-                0b10011001,
-                0b10011001,
-                0b11111011,
-                0b00000000,
-                0b00000000,
-            ]
-        )
+    fn title_screen(&self) -> &'static DotScreen {
+        const TITLE_SCREEN: DotScreen = 
+            DotScreen::new(
+                [
+                    0b00000000,
+                    0b00000000,
+                    0b11011111,
+                    0b10011001,
+                    0b10011001,
+                    0b11111011,
+                    0b00000000,
+                    0b00000000,
+                ]
+            );
+        &TITLE_SCREEN
     }
 }

--- a/src/games/traits.rs
+++ b/src/games/traits.rs
@@ -34,5 +34,5 @@ pub trait Game {
     /// 
     /// # Returns
     /// The DotScreen object which displays as the title screen.
-    fn title_screen(&self) -> DotScreen;
+    fn title_screen(&self) -> &'static DotScreen;
 }

--- a/src/peripherals/max7219/dot_screen.rs
+++ b/src/peripherals/max7219/dot_screen.rs
@@ -19,7 +19,7 @@ impl DotScreen {
     pub const TOTAL_DOTS: usize = Self::HEIGHT * Self::WIDTH;
 
     /// Creates a new DotScreen object, from the columns provided.
-    pub fn new(columns: [u8; 8]) -> Self {
+    pub const fn new(columns: [u8; 8]) -> Self {
         DotScreen { columns }
     }
 


### PR DESCRIPTION
- Added .cargo/config.toml file.
- Used the new const fn functionality of rust 1.48.0 to make the game title screen a constant, allowing the `title_screen` method of the `Game` trait to return a reference to a `DotScreen` object, rather than creating a new object upon every call.